### PR TITLE
Use the Oracle GraalVM distribution of GraalPy for better performance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
       uses: oracle-actions/login-ocir@v1.2.1
       with:
         auth_token: ${{ secrets.OCI_AUTH_TOKEN }}
+    - name: Build and Push base graalpy image
+      run: |
+        wget -O Dockerfile.graalpy https://github.com/graalvm/container/raw/master/graalpy-community/Dockerfile.ol8
+        docker build -f Dockerfile.graalpy -t graalpy:24.0.1-ol8 --build-arg GRAALVM_VERSION=24.0.1 --build-arg GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-24.0.1/graalpy-24.0.1-linux-amd64.tar.gz
     - name: Build and Push graalpyfunction
       run: |
         docker build -f Dockerfile -t fra.ocir.io/frsxwtjslf35/graalpyfunction:${{ env.NOW }} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/graalvm/graalpy-community:24.0.1-ol8
+# FROM ghcr.io/graalvm/graalpy-community:24.0.1-ol8
+# Use the Oracle GraalVM distribution of GraalPy instead of community
+FROM graalpy:24.0.1-ol8
 
 EXPOSE 8000
 

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,6 @@
+Some options to tune performance:
+
+* `--engine.Mode=latency`: prioritize startup & warmup over long-term peak performance
+* `--vm.Xmx1024m`: limit memory to this many MB
+
+These can be set in env var `GRAAL_PYTHON_ARGS` to affect all subprocesses conveniently.

--- a/src/unix_events.py
+++ b/src/unix_events.py
@@ -116,7 +116,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             signal.signal(sig, _sighandler_noop)
 
             # Set SA_RESTART to limit EINTR occurrences.
-            # raise OSError()
+            # signal.siginterrupt(sig, False)
         except OSError as exc:
             del self._signal_handlers[sig]
             if not self._signal_handlers:


### PR DESCRIPTION
It's actually just using [this Dockerfile](https://github.com/graalvm/container/blob/master/graalpy-community/Dockerfile.ol8) and changing the URL to download the Oracle GraalVM distribution of GraalPy.
(cc @timfel)

I have tested the added commands locally and it works until building the final Docker image.